### PR TITLE
timestamps.size should never be greater than 7

### DIFF
--- a/app/src/main/java/org/mercuriete/musiciantools/bpmcalculator/BPMCalculatorServiceImpl.kt
+++ b/app/src/main/java/org/mercuriete/musiciantools/bpmcalculator/BPMCalculatorServiceImpl.kt
@@ -13,16 +13,16 @@ class BPMCalculatorServiceImpl : BPMCalculatorService {
 
     override fun beat() {
         timestamps += System.nanoTime()
+        //only store maxTimestamps samples in a FIFO queue
+        if (timestamps.size > maxTimestamps) {
+            timestamps.removeAt(0)
+        }
     }
 
     override fun getBPM(): Double {
         //not enough timestamps to calculate deltas
         if (timestamps.size <= 1) {
             return 0.0
-        }
-        //only store maxTimestamps samples in a FIFO queue
-        if (timestamps.size >= maxTimestamps) {
-            timestamps.removeAt(0)
         }
         //the period is the elapsed time between the last and first beat
         //divided by number of beats between them

--- a/app/src/test/java/org/mercuriete/musiciantools/bpmcalculator/BPMCalculatorServiceUnitTest.kt
+++ b/app/src/test/java/org/mercuriete/musiciantools/bpmcalculator/BPMCalculatorServiceUnitTest.kt
@@ -3,7 +3,7 @@ package org.mercuriete.musiciantools.bpmcalculator
 import org.junit.Assert
 import org.junit.Test
 
-const val DELTA = 2.0
+const val DELTA = 0.5
 
 class BPMCalculatorServiceUnitTest {
     private var bpmCalculatorService = BPMCalculatorServiceImpl()
@@ -54,6 +54,18 @@ class BPMCalculatorServiceUnitTest {
         bpmCalculatorService.beat()
         Thread.sleep(210)
         bpmCalculatorService.beat()
+        val actual = bpmCalculatorService.getBPM()
+        Assert.assertEquals(300.0, actual, DELTA)
+    }
+
+    @Test
+    fun calculate10Beat() {
+        bpmCalculatorService.clear()
+        bpmCalculatorService.beat()
+        for (i in 1..9) {
+            Thread.sleep(200)
+            bpmCalculatorService.beat()
+        }
         val actual = bpmCalculatorService.getBPM()
         Assert.assertEquals(300.0, actual, DELTA)
     }


### PR DESCRIPTION
* Closes #31
* fix a bug where we were exceding array limits when adding elements
* add a test covering the code path where we delete elements