### PR TITLE
Update deps 2020 06

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'kotlin-android-extensions'
 
 apply plugin: 'kotlin-kapt'
 
-apply plugin: 'jacoco-android'
+apply plugin: 'com.hiya.jacoco-android'
 
 jacoco {
     toolVersion = "0.8.4"

--- a/build.gradle
+++ b/build.gradle
@@ -20,12 +20,15 @@ buildscript {
     repositories {
         google()
         jcenter()
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.3'
+        classpath 'com.android.tools.build:gradle:4.0.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:3.0"
-        classpath "com.dicedmelon.gradle:jacoco-android:0.1.4"
+        classpath "com.hiya:jacoco-android:0.2"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -51,8 +54,7 @@ sonarqube {
         property "sonar.projectVersion", project.version_name
         property "sonar.sourceEncoding", "UTF-8"
 
-        property "sonar.coverage.jacoco.xmlReportPaths", "build/reports/jacoco/jacocoTestDebugUnitTestReport/jacocoTestDebugUnitTestReport.xml"
+        property "sonar.coverage.jacoco.xmlReportPaths", "build/jacoco/jacoco.xml"
         property "sonar.junit.reportsPath", "build/test-results/testDebugUnitTest"
-        property "sonar.android.lint.report", "build/reports/lint-results.xml"
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu May 14 21:22:06 CEST 2020
+#Sat Jun 13 22:43:10 CEST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip


### PR DESCRIPTION
* Closes #33
* Update gradle wrapper
* Update android gradle plugin
* Fix a problem with jacoco android
* Fix a new path for jacoco report
* Stop sending android lint report to sonar because it is obsolete
