### PR TITLE
test: UI tests should not reference internal ids

### DIFF
--- a/app/src/androidTest/assets/features/main.feature
+++ b/app/src/androidTest/assets/features/main.feature
@@ -2,4 +2,4 @@ Feature: Open application
 
     Scenario: Successful open application
         Given I start the application
-        Then I expect to see "Hello World!" text on "bpmText" TextView
+        Then I expect to see "Hello World!" text

--- a/app/src/androidTest/assets/features/smoke.feature
+++ b/app/src/androidTest/assets/features/smoke.feature
@@ -2,11 +2,11 @@ Feature: Do smoke test
 
     Scenario: Navigate across the app and press all buttons
         Given I start the application
-        Then I click on "AboutMeFragment" view
-        Then I click on "BPMCalculatorFragment" view
-        Then I click on "AboutMeFragment" view
-        Then I click on "BPMCalculatorFragment" view
-        Then I click on "tapMe" view
-        Then I click on "tapMe" view
-        Then I click on "tapMe" view
-        Then I click on "tapMe" view
+        Then I click on "About" view
+        Then I click on "BPM Calculator" view
+        Then I click on "About" view
+        Then I click on "BPM Calculator" view
+        Then I click on "TAP ME" view
+        Then I click on "TAP ME" view
+        Then I click on "TAP ME" view
+        Then I click on "TAP ME" view

--- a/app/src/androidTest/java/org/mercuriete/musiciantools/test/GenericRobot.kt
+++ b/app/src/androidTest/java/org/mercuriete/musiciantools/test/GenericRobot.kt
@@ -3,15 +3,25 @@ package org.mercuriete.musiciantools.test
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
-import androidx.test.espresso.matcher.ViewMatchers.withResourceName
-import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.espresso.matcher.ViewMatchers.*
+import org.hamcrest.CoreMatchers.allOf
 
 open class GenericRobot {
-    fun genericAssertTextView(textViewResName: String, text: String) {
-        onView(withResourceName(textViewResName)).check(matches(withText(text)))
+    fun genericAssertTextView(text: String) {
+        onView(
+            allOf(
+                withText(text),
+                withEffectiveVisibility(Visibility.VISIBLE)
+            )
+        ).check(matches(isCompletelyDisplayed()))
     }
 
-    fun genericClickOnView(resName: String) {
-        onView(withResourceName(resName)).perform(click())
+    fun genericClickOnView(text: String) {
+        onView(
+            allOf(
+                withText(text),
+                withEffectiveVisibility(Visibility.VISIBLE)
+            )
+        ).check(matches(isCompletelyDisplayed())).perform(click())
     }
 }

--- a/app/src/androidTest/java/org/mercuriete/musiciantools/test/MainActivitySteps.kt
+++ b/app/src/androidTest/java/org/mercuriete/musiciantools/test/MainActivitySteps.kt
@@ -11,13 +11,13 @@ class MainActivitySteps {
         robot.launchMainActivityScreen()
     }
 
-    @Then("^I expect to see \"(.*)\" text on \"(.*)\" TextView$")
-    fun i_expect_to_see_a_text_message_on_textView(text: String, textViewResName: String) {
-        robot.genericAssertTextView(textViewResName, text)
+    @Then("^I expect to see \"(.*)\" text$")
+    fun i_expect_to_see_a_text_message(text: String) {
+        robot.genericAssertTextView(text)
     }
 
     @Then("^I click on \"(.*)\" view$")
-    fun i_click_on_view(resName: String) {
-        robot.genericClickOnView(resName)
+    fun i_click_on_view(text: String) {
+        robot.genericClickOnView(text)
     }
 }


### PR DESCRIPTION
* Closes #145
* Changes espresso expressions to match text content