### PR TITLE
fix(sonarqube): "usesCleartextTraffic" is implicitly enabled for olde…

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -24,7 +24,8 @@ jobs:
     - name: run instrumented tests
       uses: reactivecircus/android-emulator-runner@v2.21.0
       with:
-        api-level: 29
+        api-level: 31
+        arch: x86_64
         script: ./gradlew connectedCheck
     - name: run unitTest lint detekt and generate jacoco report
       run: ./gradlew lintDebug detektDebug testDebugUnitTest jacocoTestDebugUnitTestReport

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,7 +29,7 @@ android {
     compileSdkVersion 31
     defaultConfig {
         applicationId "org.mercuriete.musiciantools"
-        minSdkVersion 21
+        minSdkVersion 23
         targetSdkVersion 31
         versionCode project.version_code
         versionName project.version_name

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <application
         android:allowBackup="true"
         android:fullBackupContent="@xml/backup_rules"
+        android:usesCleartextTraffic = "false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"


### PR DESCRIPTION
…r Android versions

* version bump minSdkVersion to android 6.0 Marshmellow. it covers 94% of marketshare.
* disable usesCleartextTraffic explicitly
* bump emulator version on ci to be like targetSdkVersion