### PR TITLE
ci: update java requirements on azure pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,7 +19,7 @@ steps:
           gradleWrapperFile: 'gradlew'
           gradleOptions: '-Xmx3072m'
           javaHomeOption: 'JDKVersion'
-          jdkVersionOption: '1.11'
+          jdkVersionOption: '17'
           jdkArchitectureOption: 'x64'
           tasks: 'assembleDebug'
       displayName: gradlew assembleDebug


### PR DESCRIPTION
* after the fix for sonar we forgot to update azure pipelines as well